### PR TITLE
Add month filter and sort newest first

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,9 +50,13 @@
         <input type="text" id="filterInput" placeholder="店名" class="border rounded px-2 py-1 m-1" />
       </div>
       <div>
+        <label class="mr-2" for="monthFilter">篩選月份:</label>
+        <input type="month" id="monthFilter" class="border rounded px-2 py-1 m-1" />
+      </div>
+      <div>
         <label class="mr-2" for="sortSelect">排序:</label>
         <select id="sortSelect" class="border rounded px-2 py-1 m-1">
-          <option value="date">日期</option>
+          <option value="date">日期(最新在前)</option>
           <option value="profit">盈虧</option>
         </select>
       </div>

--- a/script.js
+++ b/script.js
@@ -16,6 +16,7 @@ const loginBtn = document.getElementById('loginBtn');
 const logoutBtn = document.getElementById('logoutBtn');
 const userEmailEl = document.getElementById('userEmail');
 const filterInput = document.getElementById('filterInput');
+const monthFilter = document.getElementById('monthFilter');
 const sortSelect = document.getElementById('sortSelect');
 const db = firebase.firestore();
 let currentUser = null;
@@ -23,6 +24,7 @@ let records = [];
 let editingId = null;
 let pointCost = 3.5;
 let filterText = '';
+let filterMonth = '';
 let sortField = 'date';
 
 loginBtn.addEventListener('click', () => {
@@ -50,7 +52,7 @@ async function loadRecords() {
     .collection('users')
     .doc(currentUser.uid)
     .collection('records')
-    .orderBy('date')
+    .orderBy('date', 'desc')
     .get();
   records = snap.docs.map((d) => {
     const data = d.data();
@@ -135,6 +137,10 @@ firebase.auth().onAuthStateChanged(async (user) => {
     records = [];
     pointCost = 3.5;
     costInput.value = '';
+    filterText = '';
+    filterMonth = '';
+    filterInput.value = '';
+    monthFilter.value = '';
     renderRecords();
   }
 });
@@ -150,13 +156,16 @@ function clearForm() {
 function renderRecords() {
   tbody.innerHTML = '';
   const filtered = records
-    .filter((r) => r.store.toLowerCase().includes(filterText))
+    .filter((r) =>
+      r.store.toLowerCase().includes(filterText) &&
+      (!filterMonth || r.date.startsWith(filterMonth))
+    )
     .slice()
     .sort((a, b) => {
       if (sortField === 'profit') {
         return b.profit - a.profit;
       }
-      return a.date.localeCompare(b.date);
+      return b.date.localeCompare(a.date);
     });
   let totalSpent = 0;
   let totalPoints = 0;
@@ -232,6 +241,11 @@ costInput.addEventListener('change', async function () {
 
 filterInput.addEventListener('input', function () {
   filterText = filterInput.value.trim().toLowerCase();
+  renderRecords();
+});
+
+monthFilter.addEventListener('change', function () {
+  filterMonth = monthFilter.value;
   renderRecords();
 });
 


### PR DESCRIPTION
## Summary
- add month filter UI
- support filtering by month
- show newest records first

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d5e2beba88329837c8d03046bd03f